### PR TITLE
Fix code formatting of example code in init doc

### DIFF
--- a/Sources/AppStorage/AppStorage.swift
+++ b/Sources/AppStorage/AppStorage.swift
@@ -205,15 +205,15 @@ extension AppStorageCompat where Value : RawRepresentable, Value.RawValue == Int
     ///
     /// A common usage is with enumerations:
     ///
-    ///    enum MyEnum: Int {
-    ///        case a
-    ///        case b
-    ///        case c
-    ///    }
-    ///    struct MyView: View {
-    ///        @AppStorage("MyEnumValue") private var value = MyEnum.a
-    ///        var body: some View { ... }
-    ///    }
+    ///     enum MyEnum: Int {
+    ///         case a
+    ///         case b
+    ///         case c
+    ///     }
+    ///     struct MyView: View {
+    ///         @AppStorage("MyEnumValue") private var value = MyEnum.a
+    ///         var body: some View { ... }
+    ///     }
     ///
     /// - Parameters:
     ///   - wrappedValue: The default value if an integer value
@@ -241,15 +241,15 @@ extension AppStorageCompat where Value : RawRepresentable, Value.RawValue == Str
     ///
     /// A common usage is with enumerations:
     ///
-    ///    enum MyEnum: String {
-    ///        case a
-    ///        case b
-    ///        case c
-    ///    }
-    ///    struct MyView: View {
-    ///        @AppStorage("MyEnumValue") private var value = MyEnum.a
-    ///        var body: some View { ... }
-    ///    }
+    ///     enum MyEnum: String {
+    ///         case a
+    ///         case b
+    ///         case c
+    ///     }
+    ///     struct MyView: View {
+    ///         @AppStorage("MyEnumValue") private var value = MyEnum.a
+    ///         var body: some View { ... }
+    ///     }
     ///
     /// - Parameters:
     ///   - wrappedValue: The default value if a string value


### PR DESCRIPTION
Add 1 missing space of indentation to the examples in the init function documentation so it shows as a code block.

Before:  
![Screenshot 2021-03-19 at 7 19 07 am](https://user-images.githubusercontent.com/191085/111745050-03751f00-8884-11eb-986d-9d0909de5adb.png)

After:  
![Screenshot 2021-03-19 at 7 19 59 am](https://user-images.githubusercontent.com/191085/111745070-0a9c2d00-8884-11eb-8576-056734d00581.png)
